### PR TITLE
Add compact option

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -3,10 +3,13 @@ ActiveSpace.__index  = ActiveSpace
 
 -- Metadata
 ActiveSpace.name     = "ActiveSpace"
-ActiveSpace.version  = "0.1"
+ActiveSpace.version  = "0.2"
 ActiveSpace.author   = "Michael Mogenson"
 ActiveSpace.homepage = "https://github.com/mogenson/ActiveSpace.spoon"
 ActiveSpace.license  = "MIT - https://opensource.org/licenses/MIT"
+
+-- Variables
+ActiveSpace.compact = false
 
 local function build_title()
     local title = {}
@@ -14,7 +17,9 @@ local function build_title()
     local spaces_layout = hs.spaces.allSpaces()
     local active_spaces = hs.spaces.activeSpaces()
     for _, screen in ipairs(hs.screen.allScreens()) do
-        table.insert(title, screen:name() .. ": ")
+        if not ActiveSpace.compact then
+	          table.insert(title, screen:name() .. ": ")
+        end
         local screen_uuid = screen:getUUID()
         local active_space = active_spaces[screen_uuid]
         for i, space in ipairs(spaces_layout[screen_uuid]) do
@@ -26,7 +31,7 @@ local function build_title()
             end
         end
         num_spaces = num_spaces + #spaces_layout[screen_uuid]
-        table.insert(title, "  ")
+        table.insert(title, (ActiveSpace.compact and " | " or "  "))
     end
     table.remove(title)
     return table.concat(title)
@@ -37,6 +42,11 @@ function ActiveSpace:start()
     local title = build_title()
     -- print(title)
     self.menu:setTitle(title)
+
+    self.menu:setClickCallback(function()
+        ActiveSpace.compact = not ActiveSpace.compact
+        self.menu:setTitle(build_title())
+    end)
 
     self.space_watcher = hs.spaces.watcher.new(function()
         self.menu:setTitle(build_title())

--- a/init.lua
+++ b/init.lua
@@ -18,7 +18,7 @@ local function build_title()
     local active_spaces = hs.spaces.activeSpaces()
     for _, screen in ipairs(hs.screen.allScreens()) do
         if not ActiveSpace.compact then
-	          table.insert(title, screen:name() .. ": ")
+            table.insert(title, screen:name() .. ": ")
         end
         local screen_uuid = screen:getUUID()
         local active_space = active_spaces[screen_uuid]


### PR DESCRIPTION
Add the configuration option ActiveSpace.compact which removes the display names from the menubar and adds the '|' character as a separator:

<img width="222" alt="Screenshot 2025-07-08 at 11 19 19 am" src="https://github.com/user-attachments/assets/59407f6b-6ffd-44ea-b105-43430e69df0f" />


Also toggles between compact and not compact on click.